### PR TITLE
Update mobile-config.js

### DIFF
--- a/mobile-config.js
+++ b/mobile-config.js
@@ -13,4 +13,4 @@ App.configurePlugin('cordova-plugin-device', {
 });
 
 App.addResourceFile('public/android/dev/google-services.json', 'app/google-services.json', 'android');
-App.addResourceFile('public/ios/dev/GoogleService-Info.plist', 'GoogleService-Info.plist', 'ios');
+//App.addResourceFile('public/ios/dev/GoogleService-Info.plist', 'GoogleService-Info.plist', 'ios');


### PR DESCRIPTION
This line is unconditional, which means even on Android builds, Meteor still attempts to locate this iOS file — causing a failure if it’s not present