### PR TITLE
change the UA to bypass ngrok

### DIFF
--- a/mobile-config.js
+++ b/mobile-config.js
@@ -14,3 +14,9 @@ App.configurePlugin('cordova-plugin-device', {
 
 App.addResourceFile('public/android/dev/google-services.json', 'app/google-services.json', 'android');
 //App.addResourceFile('public/ios/dev/GoogleService-Info.plist', 'GoogleService-Info.plist', 'ios');
+
+App.appendToConfig(`
+  <platform name="android">
+    <preference name="OverrideUserAgent" value="MIEWEB Auth App/1.0 (Android)" />
+  </platform>
+`);


### PR DESCRIPTION
Sets a unique User-Agent for the Android app so that local tests can utilize NGROK for proxying. Needed to get the Docker Compose to reproduce #135 working. See https://github.com/runleveldev/mieweb_auth_app-135-repro